### PR TITLE
fixed dockerised builds added run script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ ENV GOPATH /go
 ENV GO111MODULE on
 RUN mkdir -p /go/src/github.com/logzio/logzio_terraform_provider
 WORKDIR /go/src/github.com/logzio/logzio_terraform_provider
-COPY . .
+ENTRYPOINT [ "go", "build" ]

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker build -t logzio_terraform_provider_build .
+docker run -v `pwd`:/go/src/github.com/logzio/logzio_terraform_provider: logzio_terraform_provider_build


### PR DESCRIPTION
The dockerfile in this repo is intended to allow for a dockerised build.  You don't need go on your machine to build the source code, run the scripts/build_docker.sh file and it'll create a docker container that builds the source code and leaves the executable in your working directory.  (ps. it wasn't about distributing the provider as a container)