### PR TITLE
1.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.15
 require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/logzio/logzio_terraform_client v1.5.1
+	github.com/logzio/logzio_terraform_client v1.5.2
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/logzio/logzio_terraform_provider
 
-go 1.12
+go 1.15
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/hashicorp/terraform v0.12.6
+	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/logzio/logzio_terraform_client v1.5.1
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.7.0
 )

--- a/logzio/datasource_alert.go
+++ b/logzio/datasource_alert.go
@@ -2,7 +2,7 @@ package logzio
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/logzio/logzio_terraform_client/alerts"
 	"time"
 )

--- a/logzio/datasource_alert_test.go
+++ b/logzio/datasource_alert_test.go
@@ -1,7 +1,7 @@
 package logzio
 
 import (
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"testing"
 )
 

--- a/logzio/datasource_alert_v2.go
+++ b/logzio/datasource_alert_v2.go
@@ -2,7 +2,7 @@ package logzio
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/logzio/logzio_terraform_client/alerts_v2"
 	"time"
 )

--- a/logzio/datasource_alert_v2_test.go
+++ b/logzio/datasource_alert_v2_test.go
@@ -1,7 +1,7 @@
 package logzio
 
 import (
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"testing"
 )
 

--- a/logzio/datasource_endpoint.go
+++ b/logzio/datasource_endpoint.go
@@ -3,7 +3,7 @@ package logzio
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 )
 

--- a/logzio/datasource_endpoint_test.go
+++ b/logzio/datasource_endpoint_test.go
@@ -1,7 +1,7 @@
 package logzio
 
 import (
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"regexp"
 	"testing"
 )

--- a/logzio/datasource_subaccount.go
+++ b/logzio/datasource_subaccount.go
@@ -2,7 +2,7 @@ package logzio
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/logzio/logzio_terraform_client/sub_accounts"
 )
 

--- a/logzio/datasource_subaccount_test.go
+++ b/logzio/datasource_subaccount_test.go
@@ -2,7 +2,7 @@ package logzio
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
 	"strconv"
 	"testing"

--- a/logzio/datasource_user.go
+++ b/logzio/datasource_user.go
@@ -2,7 +2,7 @@ package logzio
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/logzio/logzio_terraform_client/users"
 )
 

--- a/logzio/datasource_user_test.go
+++ b/logzio/datasource_user_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
 func TestAccDataSourceUser(t *testing.T) {

--- a/logzio/provider.go
+++ b/logzio/provider.go
@@ -2,8 +2,8 @@ package logzio
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 const (
@@ -11,7 +11,7 @@ const (
 	providerBaseUrl        = "base_url"
 	providerRegion         = "region"
 	resourceAlertType      = "logzio_alert"
-	resourceAlertV2Type = "logzio_alert_v2"
+	resourceAlertV2Type    = "logzio_alert_v2"
 	resourceEndpointType   = "logzio_endpoint"
 	resourceUserType       = "logzio_user"
 	resourceSubAccountType = "logzio_subaccount"
@@ -46,14 +46,14 @@ func Provider() terraform.ResourceProvider {
 			resourceEndpointType:   dataSourceEndpoint(),
 			resourceUserType:       dataSourceUser(),
 			resourceSubAccountType: dataSourceSubAccount(),
-			resourceAlertV2Type: dataSourceAlertV2(),
+			resourceAlertV2Type:    dataSourceAlertV2(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			resourceAlertType:      resourceAlert(),
 			resourceEndpointType:   resourceEndpoint(),
 			resourceUserType:       resourceUser(),
 			resourceSubAccountType: resourceSubAccount(),
-			resourceAlertV2Type: resourceAlertV2(),
+			resourceAlertV2Type:    resourceAlertV2(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/logzio/provider_test.go
+++ b/logzio/provider_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 var (

--- a/logzio/resource_alert.go
+++ b/logzio/resource_alert.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/logzio/logzio_terraform_client/alerts"
 	"log"
 	"strconv"

--- a/logzio/resource_alert_test.go
+++ b/logzio/resource_alert_test.go
@@ -2,7 +2,7 @@ package logzio
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"io/ioutil"
 	"log"
 	"testing"

--- a/logzio/resource_alert_v2.go
+++ b/logzio/resource_alert_v2.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/avast/retry-go"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/logzio/logzio_terraform_client/alerts_v2"
 	"log"
 	"reflect"
@@ -300,6 +300,9 @@ func resourceAlertV2Create(d *schema.ResourceData, m interface{}) error {
 				return false
 			}),
 		retry.Delay(delayGetAlertV2),
+		retry.DelayType(func(n uint, err error, config *retry.Config) time.Duration{
+			return retry.BackOffDelay(n, err, config)
+		}),
 	)
 }
 
@@ -360,6 +363,9 @@ func resourceAlertV2Update(d *schema.ResourceData, m interface{}) error {
 				return false
 			}),
 		retry.Delay(delayGetAlertV2),
+		retry.DelayType(func(n uint, err error, config *retry.Config) time.Duration{
+			return retry.BackOffDelay(n, err, config)
+		}),
 	)
 }
 

--- a/logzio/resource_alert_v2_test.go
+++ b/logzio/resource_alert_v2_test.go
@@ -2,7 +2,7 @@ package logzio
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/logzio/logzio_terraform_client/alerts_v2"
 	"io/ioutil"
 	"log"

--- a/logzio/resource_endpoint.go
+++ b/logzio/resource_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 )
 

--- a/logzio/resource_endpoint.go
+++ b/logzio/resource_endpoint.go
@@ -98,7 +98,7 @@ func resourceEndpoint() *schema.Resource {
 						},
 						endpointHeaders: {
 							Type:     schema.TypeMap,
-							Required: true,
+							Optional: true,
 						},
 						endpointBodyTemplate: {
 							Type:     schema.TypeMap,

--- a/logzio/resource_endpoint_test.go
+++ b/logzio/resource_endpoint_test.go
@@ -236,3 +236,32 @@ func createCustomEndpoint(name string) string {
 	}
 	return fmt.Sprintf(fmt.Sprintf("%s", content), name)
 }
+
+func TestAccLogzioEndpoint_CreateCustomEndpointNoHeaders(t *testing.T) {
+	config := `resource "logzio_endpoint" "custom" {
+  title = "my_custom_title_no_headers"
+  endpoint_type = "Custom"
+  description = "this_is_my_description"
+  custom {
+    url = "https://www.test.com"
+    method = "POST"
+    body_template = {
+      this = "is"
+      my = "template"
+    }
+  }
+}`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckApiToken(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"logzio_endpoint.custom", "title", "my_custom_title_no_headers"),
+				),
+			},
+		},
+	})
+}

--- a/logzio/resource_endpoint_test.go
+++ b/logzio/resource_endpoint_test.go
@@ -3,8 +3,8 @@ package logzio
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"io/ioutil"
 	"log"
 	"regexp"

--- a/logzio/resource_subaccount_test.go
+++ b/logzio/resource_subaccount_test.go
@@ -2,17 +2,16 @@ package logzio
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
-	"strconv"
 	"testing"
 )
 
 func TestAccLogzioSubaccount_CreateSubaccount(t *testing.T) {
-
-	accountId, _ := strconv.ParseInt(os.Getenv(envLogzioAccountId), BASE_10, BITSIZE_64)
+	accountId := os.Getenv(envLogzioAccountId)
 	email := os.Getenv(envLogzioEmail)
-	terraformPlan := testAccCheckLogzioSubaccountConfig(email, accountId)
+	accountName := "test"
+	terraformPlan := testAccCheckLogzioSubaccountConfig(email, accountName, accountId)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -40,16 +39,85 @@ func TestAccLogzioSubaccount_CreateSubaccount(t *testing.T) {
 	})
 }
 
-func testAccCheckLogzioSubaccountConfig(email string, accountId int64) string {
+func TestAccLogzioSubaccount_CreateSubaccountEmptySharingObject(t *testing.T) {
+	email := os.Getenv(envLogzioEmail)
+	accountName := "test_empty_sharing_object"
+	terraformPlan := testAccCheckLogzioSubaccountConfig(email, accountName, "")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckApiToken(t)
+			testAccPreCheckEmail(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: terraformPlan,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"logzio_subaccount.test_subaccount", "email", email),
+				),
+			},
+			{
+				Config:                  terraformPlan,
+				ResourceName:            "logzio_subaccount.test_subaccount",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"email"},
+			},
+		},
+	})
+}
+
+func TestAccLogzioSubaccount_UpdateSubaccount(t *testing.T) {
+	accountId := os.Getenv(envLogzioAccountId)
+	email := os.Getenv(envLogzioEmail)
+	accountName := "test_update_before"
+	accountNameUpdate := "test_update_after"
+	resourceName := "logzio_subaccount.test_subaccount"
+	terraformPlan := testAccCheckLogzioSubaccountConfig(email, accountName, accountId)
+	terraformPlanUpdate := testAccCheckLogzioSubaccountConfig(email, accountNameUpdate, accountId)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckApiToken(t)
+			testAccPreCheckAccountId(t)
+			testAccPreCheckEmail(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: terraformPlan,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						resourceName, "email", email),
+				),
+			},
+			{
+				Config: terraformPlanUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						resourceName, subAccountName, accountNameUpdate),
+				),
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{subAccountEmail},
+			},
+		},
+	})
+}
+
+func testAccCheckLogzioSubaccountConfig(email string, accountName string, accountId string) string {
 	return fmt.Sprintf(`
 resource "logzio_subaccount" "test_subaccount" {
   email = "%s"
-  account_name = "test"
+  account_name = "%s"
   retention_days = 2
   max_daily_gb = 1
   sharing_objects_accounts = [
-    %d
+    %s
   ]
 }
-`, email, accountId)
+`, email, accountName, accountId)
 }

--- a/logzio/resource_user.go
+++ b/logzio/resource_user.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/logzio/logzio_terraform_client/users"
 )
 

--- a/logzio/resource_user_test.go
+++ b/logzio/resource_user_test.go
@@ -2,7 +2,7 @@ package logzio
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
 	"strconv"
 	"testing"

--- a/logzio/validators_test.go
+++ b/logzio/validators_test.go
@@ -44,7 +44,7 @@ func TestValidUrl(t *testing.T) {
 }
 
 func TestValidateOutputTypes(t *testing.T) {
-	validOptions := []string {
+	validOptions := []string{
 		alerts_v2.OutputTypeJson,
 		alerts_v2.OutputTypeTable,
 	}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/plugin"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/logzio/logzio_terraform_provider/logzio"
 )
 

--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,8 @@ Want to do it yourself? We are more than happy to accept external contributions 
 Simply fork the repo, add your changes and [open a PR](https://github.com/logzio/logzio_terraform_provider/pulls).
 
 ### Changelog 
+- v1.2.3
+    - Fix bug for `custom endpoint` empty headers.
 - v1.2.2
     - Update client version(v1.5.1).
     - Fix alerts_v2 sort bug.

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,9 @@ Simply fork the repo, add your changes and [open a PR](https://github.com/logzio
 ### Changelog 
 - v1.2.3
     - Fix bug for `custom endpoint` empty headers.
+    - Allow empty sharing accounts array in `sub account`.
+    - Replace module `terraform` with `terraform-plugin-sdk`. See further explanation [here](https://www.terraform.io/docs/extend/guides/v1-upgrade-guide.html).
+    - Upgrade to Go v1.15.
 - v1.2.2
     - Update client version(v1.5.1).
     - Fix alerts_v2 sort bug.

--- a/readme.md
+++ b/readme.md
@@ -158,6 +158,7 @@ Simply fork the repo, add your changes and [open a PR](https://github.com/logzio
 - v1.2.3
     - Fix bug for `custom endpoint` empty headers.
     - Allow empty sharing accounts array in `sub account`.
+    - Add retry in resource `sub account`.
     - Replace module `terraform` with `terraform-plugin-sdk`. See further explanation [here](https://www.terraform.io/docs/extend/guides/v1-upgrade-guide.html).
     - Upgrade to Go v1.15.
     - Update client version(v1.5.2).

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,7 @@ Simply fork the repo, add your changes and [open a PR](https://github.com/logzio
     - Allow empty sharing accounts array in `sub account`.
     - Replace module `terraform` with `terraform-plugin-sdk`. See further explanation [here](https://www.terraform.io/docs/extend/guides/v1-upgrade-guide.html).
     - Upgrade to Go v1.15.
+    - Update client version(v1.5.2).
 - v1.2.2
     - Update client version(v1.5.1).
     - Fix alerts_v2 sort bug.

--- a/utils/template.go
+++ b/utils/template.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
-	tf "github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	tf "github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/logzio/logzio_terraform_provider/logzio"
 
 	"encoding/json"


### PR DESCRIPTION
This PR:
    - Fix bug for `custom endpoint` empty headers.
    - Allow empty sharing accounts array in `sub account`.
    - Replace module `terraform` with `terraform-plugin-sdk`. See further explanation [here](https://www.terraform.io/docs/extend/guides/v1-upgrade-guide.html).
    - Upgrade to Go v1.15.
    - Update client version(v1.5.2).