### PR TITLE
update client version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.15
 require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/logzio/logzio_terraform_client v1.9.0
+	github.com/logzio/logzio_terraform_client v1.9.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/readme.md
+++ b/readme.md
@@ -188,11 +188,15 @@ terraform import logzio_subaccount.logzio_sa_<ACCOUNT-NAME> <ACCOUNT-ID>
 ```
 
 ### Changelog
-
+- **v1.6.1**
+    - Update client version (v1.9.1) - bug fix for not found messages.
 - **v1.6**
   - Update client version (v1.9).
   - Support [archive logs resource](https://docs.logz.io/api/#tag/Archive-logs).
   - Support [restore logs resource](https://docs.logz.io/api/#tag/Restore-logs).
+
+<details>
+  <summary markdown="span"> Expand to check old versions </summary>
 - **v1.5**
     - Update client version(v1.8).
     - `sub_account`:
@@ -214,9 +218,6 @@ terraform import logzio_subaccount.logzio_sa_<ACCOUNT-NAME> <ACCOUNT-ID>
         - Refactor code to use Terraform's retry.
     - `drop_filter`:
         - Improve tests.
-<details>
-  <summary markdown="span"> Expand to check old versions </summary>
-
 - v1.4
     - Update client version(v1.7).
     - Support [Drop Filter](https://docs.logz.io/api/#tag/Drop-filters) resource.
@@ -226,10 +227,6 @@ terraform import logzio_subaccount.logzio_sa_<ACCOUNT-NAME> <ACCOUNT-ID>
 - v1.2.4
     - Update client version(v1.5.3).
     - Fix `sub account` to return attributes `account_token` & `account_id`.
-
-<details>
-  <summary markdown="span">Expand to check old versions </summary>
-
 - v1.2.3
     - Fix bug for `custom endpoint` empty headers.
     - Allow empty sharing accounts array in `sub account`.


### PR DESCRIPTION
Bug fix - the retryable errors rely on strings with the specific resource name to find a 404 error.
The previous client version had a bug in which all the not found errors had an "archive" resource name.
The new client version fixes this issue.
This PR updates the provider to use the new (& fixed) version of the client.