### PR TITLE
1.8.0

### DIFF
--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -40,7 +40,7 @@ resource "logzio_endpoint" "my_endpoint" {
 * `custom` - (Optional) Relevant when `endpoint_type` is `custom`. Manages a custom webhook for your integration of choice.
     * `url` - Specifies the URL destination.
     * `method` - Selects the HTTP request method.
-    * `headers` - Header parameters for the request. Sent as comma-separated key-value pairs.
+    * `headers` - Header parameters for the request. String, sent as comma-separated key-value pairs.
     * `body_template` - string of JSON object that serves as the template for the message body.
 * `opsgenie` - (Optional) Relevant when `endpoint_type` is `opsgenie`. Manages a webhook to OpsGenie.
     * `api_key` - API key from OpsGenie, see https://docs.opsgenie.com/docs/logz-io-integration.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.15
 require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/logzio/logzio_terraform_client v1.10.0
+	github.com/logzio/logzio_terraform_client v1.10.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/logzio/datasource_endpoint.go
+++ b/logzio/datasource_endpoint.go
@@ -23,6 +23,10 @@ func dataSourceEndpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			endpointDescription: {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }

--- a/logzio/resource_endpoint.go
+++ b/logzio/resource_endpoint.go
@@ -341,7 +341,8 @@ func getCreateOrUpdateEndpointFromSchema(d *schema.ResourceData) endpoints.Creat
 	case endpoints.EndpointTypeCustom:
 		createEndpoint.Url = opts[endpointUrl].(string)
 		createEndpoint.Method = opts[endpointMethod].(string)
-		createEndpoint.Headers = opts[endpointHeaders].(string)
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = opts[endpointHeaders].(string)
 		createEndpoint.BodyTemplate = utils.ParseFromStringToType(opts[endpointBodyTemplate].(string))
 	case endpoints.EndpointTypePagerDuty:
 		createEndpoint.ServiceKey = opts[endpointServiceKey].(string)

--- a/logzio/resource_endpoint.go
+++ b/logzio/resource_endpoint.go
@@ -112,7 +112,7 @@ func resourceEndpoint() *schema.Resource {
 							ValidateFunc: utils.ValidateHttpMethod,
 						},
 						endpointHeaders: {
-							Type:     schema.TypeMap,
+							Type:     schema.TypeString,
 							Optional: true,
 						},
 						endpointBodyTemplate: {
@@ -341,11 +341,7 @@ func getCreateOrUpdateEndpointFromSchema(d *schema.ResourceData) endpoints.Creat
 	case endpoints.EndpointTypeCustom:
 		createEndpoint.Url = opts[endpointUrl].(string)
 		createEndpoint.Method = opts[endpointMethod].(string)
-		headerMap := make(map[string]string)
-		for k, v := range opts[endpointHeaders].(map[string]interface{}) {
-			headerMap[k] = v.(string)
-		}
-		createEndpoint.Headers = utils.ParseObjectToString(headerMap)
+		createEndpoint.Headers = opts[endpointHeaders].(string)
 		createEndpoint.BodyTemplate = utils.ParseFromStringToType(opts[endpointBodyTemplate].(string))
 	case endpoints.EndpointTypePagerDuty:
 		createEndpoint.ServiceKey = opts[endpointServiceKey].(string)
@@ -410,7 +406,7 @@ func setEndpoint(d *schema.ResourceData, endpoint *endpoints.Endpoint) {
 		set[0] = map[string]interface{}{
 			endpointUrl:          endpoint.Url,
 			endpointMethod:       endpoint.Method,
-			endpointHeaders:      utils.ParseFromStringToType(endpoint.Headers),
+			endpointHeaders:      endpoint.Headers,
 			endpointBodyTemplate: utils.ParseObjectToString(endpoint.BodyTemplate),
 		}
 	case endpoints.EndpointTypePagerDuty:

--- a/logzio/resource_endpoint_test.go
+++ b/logzio/resource_endpoint_test.go
@@ -129,7 +129,7 @@ func TestAccLogzioEndpoint_CustomCreateEndpointNoHeaders(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						resourceName, "title", "my_custom_title_no_headers"),
-					resource.TestCheckNoResourceAttr(resourceName, "custom.2885600711.headers"),
+					resource.TestCheckResourceAttr(resourceName, "custom.2688962798.headers", ""),
 				),
 			},
 			{
@@ -162,7 +162,7 @@ func TestAccLogzioEndpoint_CustomCreateEndpointEmptyBodyTemplate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						resourceName, "title", "my_custom_title_empty_body_template"),
-					resource.TestCheckResourceAttr(resourceName, "custom.3152454932.body_template", "{}"),
+					resource.TestCheckResourceAttr(resourceName, "custom.1831890258.body_template", "{}"),
 				),
 			},
 			{
@@ -212,8 +212,8 @@ func TestAccLogzioEndpoint_CustomUpdateEndpoint(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						resourceName, "title", "my_custom_title"),
-					resource.TestCheckResourceAttr(resourceName, "custom.1180081054.url", testsUrl),
-					resource.TestCheckResourceAttr(resourceName, "custom.1180081054.method", http.MethodPost),
+					resource.TestCheckResourceAttr(resourceName, "custom.552452041.url", testsUrl),
+					resource.TestCheckResourceAttr(resourceName, "custom.552452041.method", http.MethodPost),
 				),
 			},
 			{
@@ -221,10 +221,10 @@ func TestAccLogzioEndpoint_CustomUpdateEndpoint(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						resourceName, "title", "updated_custom_endpoint"),
-					resource.TestCheckResourceAttr(resourceName, "custom.3222268320.url", testsUrlUpdate),
-					resource.TestCheckResourceAttr(resourceName, "custom.3222268320.method", http.MethodPut),
-					resource.TestCheckNoResourceAttr(resourceName, "custom.3222268320.headers"),
-					resource.TestCheckResourceAttr(resourceName, "custom.3222268320.body_template", "{}"),
+					resource.TestCheckResourceAttr(resourceName, "custom.1435031376.url", testsUrlUpdate),
+					resource.TestCheckResourceAttr(resourceName, "custom.1435031376.method", http.MethodPut),
+					resource.TestCheckResourceAttr(resourceName, "custom.1435031376.headers", ""),
+					resource.TestCheckResourceAttr(resourceName, "custom.1435031376.body_template", "{}"),
 				),
 			},
 		},

--- a/logzio/testdata/fixtures/create_custom_endpoint.tf
+++ b/logzio/testdata/fixtures/create_custom_endpoint.tf
@@ -5,10 +5,7 @@ resource "logzio_endpoint" "%s" {
   custom {
     url = "https://jsonplaceholder.typicode.com/todos/1"
     method = "POST"
-    headers = {
-      this = "is"
-      a = "header"
-    }
+    headers = "this=is,a=header"
     body_template = jsonencode({
       this: "is"
       my: "template"

--- a/logzio/testdata/fixtures/update_custom_endpoint.tf
+++ b/logzio/testdata/fixtures/update_custom_endpoint.tf
@@ -6,5 +6,6 @@ resource "logzio_endpoint" "%s" {
     url = "https://jsonplaceholder.typicode.com/todos/2"
     method = "PUT"
     body_template = jsonencode({})
+    headers = ""
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -190,16 +190,20 @@ terraform import logzio_subaccount.logzio_sa_<ACCOUNT-NAME> <ACCOUNT-ID>
 
 ### Changelog
 
+- **v1.8.0**
+    - **Breaking change**: **custom endpoint** - refactor Headers - now a string of comma-seperated key-value pairs.
+    - Update client version (v1.10.1) - bug fix for empty Header field.
+    - Add to custom endpoint datasource Description field.
 - **v1.7.0**
   - Update client version (v1.10).
   - Support [authentication groups resource](https://docs.logz.io/api/#tag/Authentication-groups).
   - `alerts_v2`: fix noisy diff for `severity_threshold_tiers`.
-- **v1.6.1**
-    - Update client version (v1.9.1) - bug fix for not found messages.
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
-  
+
+- **v1.6.1**
+    - Update client version (v1.9.1) - bug fix for not found messages.
 - **v1.6**
   - Update client version (v1.9).
   - Support [archive logs resource](https://docs.logz.io/api/#tag/Archive-logs).


### PR DESCRIPTION
### v1.8.0
- **Breaking change**: **custom endpoint** - refactor Headers - now a string of comma-seperated key-value pairs.
- Update client version (v1.10.1) - bug fix for empty Header field.
- Add to custom endpoint datasource Description field.