### PR TITLE
add ignore for windows/arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,10 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
+      - goos: windows
+        goarch: arm64
+        # The ignore windows/arm64 section can be removed once we'll upgrade the go version to 1.17
+        # For more info: https://github.com/goreleaser/goreleaser/pull/3157
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip


### PR DESCRIPTION
A possible fix for the failure of the release action, caused by build for windows/arm64.
The release action always uses the latest version of goreleaser, which is currently 1.10.2.
Until version 1.10.0, the goreleaser automatically ignored the combination of windows/arm64.
[As of 1.10.0](https://github.com/goreleaser/goreleaser/releases/tag/v1.10.0) - it no longer ignores it, as Go 1.17 now allows this combination.
Since we are using Go 1.16, the build for this combination fails.
In this PR we explicitly instruct the goreleaser to ignore a build for windows/arm.
When we'll upgrade our provider to Go 1.17, we can remove this addition.

More info about this can be found [here](https://goreleaser.com/deprecations/#builds-for-windowsarm64).