### PR TITLE
Catch error when reading archive settings

### DIFF
--- a/logzio/resource_archive_logs.go
+++ b/logzio/resource_archive_logs.go
@@ -186,6 +186,9 @@ func resourceArchiveLogsRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	archive, err := archiveLogsClient(m).RetrieveArchiveLogsSetting(int32(id))
+	if err != nil {
+		return err
+	}
 	setArchive(d, archive)
 	return nil
 }

--- a/readme.md
+++ b/readme.md
@@ -190,10 +190,14 @@ terraform import logzio_subaccount.logzio_sa_<ACCOUNT-NAME> <ACCOUNT-ID>
 ```
 
 ### Changelog
-
+- **v1.9.1**
+    - *Bug fix*: plugin won't crash when import for `archive_logs` fails.
 - **v1.9.0**
     - Update client version(v1.11.0).
     - Support [Kibana objects](https://docs.logz.io/api/#tag/Import-or-export-Kibana-objects)
+
+<details>
+  <summary markdown="span"> Expand to check old versions </summary>
 - **v1.8.3**
     - Update client version(v1.10.3).
     - Bug fixes:
@@ -201,10 +205,6 @@ terraform import logzio_subaccount.logzio_sa_<ACCOUNT-NAME> <ACCOUNT-ID>
           - Fix noisy diff for tags.
           - Field `is_enabled` defaults to `true`.
         - **sub_accounts**: allow creating flexible account without `max_daily_gb`.
-
-
-<details>
-  <summary markdown="span"> Expand to check old versions </summary>
 - **v1.8.2**
     - Update client version(v1.10.2).
     - Bug fixes:


### PR DESCRIPTION
At the moment - when trying to import archive settings that don't exist - the plugin crashes.
This happens due to the fact that the Read function for that resource is missing a line that checks if the api returned an error.
This PR fixes that bug.