### PR TITLE
Fix diff for alerts_v2 on mail and endpoint notifications.

### DIFF
--- a/logzio/datasource_alert_v2.go
+++ b/logzio/datasource_alert_v2.go
@@ -24,7 +24,7 @@ func dataSourceAlertV2() *schema.Resource {
 				Computed: true,
 			},
 			alertV2Tags: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -39,14 +39,14 @@ func dataSourceAlertV2() *schema.Resource {
 				Computed: true,
 			},
 			alertV2NotificationEmails: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			alertV2NotificationEndpoints: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeInt,

--- a/logzio/resource_alert_v2.go
+++ b/logzio/resource_alert_v2.go
@@ -101,14 +101,14 @@ func resourceAlertV2() *schema.Resource {
 				Default:  true,
 			},
 			alertV2NotificationEmails: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			alertV2NotificationEndpoints: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeInt,
@@ -543,7 +543,9 @@ func createCreateAlertType(d *schema.ResourceData) alerts_v2.CreateAlertType {
 	tags := getTags(d)
 	subComponentsFromConfig := d.Get(alertV2SubComponents).([]interface{})
 	subComponents := getSubComponents(subComponentsFromConfig)
-	recipients := getRecipients(d.Get(alertV2NotificationEmails).([]interface{}), d.Get(alertV2NotificationEndpoints).([]interface{}))
+	emails := d.Get(alertV2NotificationEmails).(*schema.Set).List()
+	endpoints := d.Get(alertV2NotificationEndpoints).(*schema.Set).List()
+	recipients := getRecipients(emails, endpoints)
 
 	alertOutput := alerts_v2.AlertOutput{
 		Recipients:                   *recipients,

--- a/readme.md
+++ b/readme.md
@@ -190,14 +190,18 @@ terraform import logzio_subaccount.my_subaccount <SUBACCOUNT-ID>
 ```
 
 ### Changelog
+
+- **v1.9.2**
+    - *Bug fix*: Fix diff for resource `alert_v2` in fields `alert_notification_endpoints`, `notification_emails` ([#116](https://github.com/logzio/terraform-provider-logzio/issues/116)).
 - **v1.9.1**
     - *Bug fix*: plugin won't crash when import for `archive_logs` fails.
-- **v1.9.0**
-    - Update client version(v1.11.0).
-    - Support [Kibana objects](https://docs.logz.io/api/#tag/Import-or-export-Kibana-objects)
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
+
+- **v1.9.0**
+    - Update client version(v1.11.0).
+    - Support [Kibana objects](https://docs.logz.io/api/#tag/Import-or-export-Kibana-objects)
 - **v1.8.3**
     - Update client version(v1.10.3).
     - Bug fixes:


### PR DESCRIPTION
Fixes #116 .
In this PR:
- In resource `alert_v2`, changed fields `alert_notification_endpoints`, `notification_emails` from TypeList to TypeSet, to avoid diff when applying changes.