### PR TITLE
refactor resource archive + tests

### DIFF
--- a/logzio/resource_archive_logs_test.go
+++ b/logzio/resource_archive_logs_test.go
@@ -2,7 +2,7 @@ package logzio
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/logzio/logzio_terraform_client/archive_logs"
 	"github.com/logzio/logzio_terraform_provider/logzio/utils"
 	"os"
@@ -25,31 +25,24 @@ func TestAccLogzioArchiveLogs_SetupArchiveS3Keys(t *testing.T) {
 	defer utils.SleepAfterTest()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckApiToken(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheckApiToken(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: getConfigTestArchiveS3Keys(resourceName, path, accessKey, secretKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsStorageType, archive_logs.StorageTypeS3),
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsEnabled, "false"),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3CredentialsType,
-						archive_logs.CredentialsTypeKeys),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3Path, path),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3SecretCredentials+".0."+archiveLogsS3AccessKey,
-						accessKey),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3SecretCredentials+".0."+archiveLogsS3SecretKey,
-						secretKey),
+					resource.TestCheckResourceAttr(fullResourceName, archiveLogsS3CredentialsType, archive_logs.CredentialsTypeKeys),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3Path),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3AccessKey),
 				),
 			},
 			{
-				ResourceName:      fullResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            fullResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{archiveLogsS3SecretKey},
 			},
 		},
 	})
@@ -63,8 +56,8 @@ func TestAccLogzioArchiveLogs_SetupArchiveS3Iam(t *testing.T) {
 	defer utils.SleepAfterTest()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckApiToken(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheckApiToken(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: getConfigTestArchiveS3Iam(resourceName, path, arn),
@@ -72,16 +65,10 @@ func TestAccLogzioArchiveLogs_SetupArchiveS3Iam(t *testing.T) {
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsStorageType, archive_logs.StorageTypeS3),
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsEnabled, "true"),
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsCompressed, "false"),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3CredentialsType,
-						archive_logs.CredentialsTypeIam),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3Path, path),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3IamCredentialsArn,
-						arn),
-					resource.TestCheckResourceAttrSet(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3ExternalId),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3CredentialsType),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3Path),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3IamCredentialsArn),
+					//resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3ExternalId),
 				),
 			},
 			{
@@ -105,8 +92,8 @@ func TestAccLogzioArchiveLogs_SetupArchiveBlob(t *testing.T) {
 	defer utils.SleepAfterTest()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckApiToken(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheckApiToken(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: getConfigTestArchiveBlob(resourceName, tenantId, clientId, clientSecret, accountName, containerName),
@@ -114,24 +101,17 @@ func TestAccLogzioArchiveLogs_SetupArchiveBlob(t *testing.T) {
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsStorageType, archive_logs.StorageTypeBlob),
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsEnabled, "true"),
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsCompressed, "true"),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAzureBlobStorageSettings+".0."+archiveLogsBlobTenantId,
-						tenantId),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAzureBlobStorageSettings+".0."+archiveLogsBlobClientId, clientId),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAzureBlobStorageSettings+".0."+archiveLogsBlobClientSecret,
-						clientSecret),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAzureBlobStorageSettings+".0."+archiveLogsBlobAccountName, accountName),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAzureBlobStorageSettings+".0."+archiveLogsBlobContainerName, containerName),
-				),
-			},
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsBlobTenantId),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsBlobClientId),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsBlobClientSecret),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsBlobAccountName),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsBlobContainerName),
+				)},
 			{
-				ResourceName:      fullResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            fullResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{archiveLogsBlobClientSecret},
 			},
 		},
 	})
@@ -145,8 +125,8 @@ func TestAccLogzioArchiveLogs_SetupArchiveEmptyStorageType(t *testing.T) {
 	defer utils.SleepAfterTest()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckApiToken(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheckApiToken(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      getConfigTestArchiveEmptyStorageType(resourceName, path, accessKey, secretKey),
@@ -164,8 +144,8 @@ func TestAccLogzioArchiveLogs_SetupArchiveEmptyS3CredentialsType(t *testing.T) {
 	defer utils.SleepAfterTest()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckApiToken(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheckApiToken(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      getConfigTestArchiveEmptyCredentialsType(resourceName, path, accessKey, secretKey),
@@ -186,46 +166,32 @@ func TestAccLogzioArchiveLogs_UpdateArchive(t *testing.T) {
 	defer utils.SleepAfterTest()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckApiToken(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheckApiToken(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: getConfigTestArchiveS3Keys(resourceName, path, accessKey, secretKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsStorageType, archive_logs.StorageTypeS3),
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsEnabled, "false"),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3CredentialsType,
-						archive_logs.CredentialsTypeKeys),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3Path, path),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3SecretCredentials+".0."+archiveLogsS3AccessKey,
-						accessKey),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3SecretCredentials+".0."+archiveLogsS3SecretKey,
-						secretKey),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3CredentialsType),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3Path),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3AccessKey),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3SecretKey),
 				),
 			},
 			{
 				PreConfig: func() {
-					time.Sleep(2 * time.Second)
+					time.Sleep(3 * time.Second)
 				},
 				Config: getConfigTestArchiveS3Keys(resourceName, path, newAccessKey, newSecretKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsStorageType, archive_logs.StorageTypeS3),
 					resource.TestCheckResourceAttr(fullResourceName, archiveLogsEnabled, "false"),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3CredentialsType,
-						archive_logs.CredentialsTypeKeys),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3Path, path),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3SecretCredentials+".0."+archiveLogsS3AccessKey,
-						newAccessKey),
-					resource.TestCheckResourceAttr(fullResourceName,
-						archiveLogsAmazonS3StorageSettings+".0."+archiveLogsS3SecretCredentials+".0."+archiveLogsS3SecretKey,
-						newSecretKey),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3CredentialsType),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3Path),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3AccessKey),
+					resource.TestCheckResourceAttrSet(fullResourceName, archiveLogsS3SecretKey),
 				),
 			},
 		},
@@ -236,14 +202,10 @@ func getConfigTestArchiveS3Keys(name string, path string, accessKey string, secr
 	return fmt.Sprintf(`resource "logzio_archive_logs" "%s" {
  storage_type = "S3"
  enabled = false
- amazon_s3_storage_settings {
-   credentials_type = "KEYS"
-   s3_path = "%s"
-   s3_secret_credentials {
-		access_key = "%s"
-		secret_key = "%s"
-	}
- }
+ credentials_type = "KEYS"
+ s3_path = "%s"
+ aws_access_key = "%s"
+ aws_secret_key = "%s"
 }
 `, name, path, accessKey, secretKey)
 }
@@ -252,11 +214,9 @@ func getConfigTestArchiveS3Iam(name string, path string, arn string) string {
 	return fmt.Sprintf(`resource "logzio_archive_logs" "%s" {
  storage_type = "S3"
  compressed = false
- amazon_s3_storage_settings {
-   credentials_type = "IAM"
-   s3_path = "%s"
-   s3_iam_credentials_arn = "%s"
- }
+ credentials_type = "IAM"
+ s3_path = "%s"
+ s3_iam_credentials_arn = "%s"
 }
 `, name, path, arn)
 }
@@ -265,13 +225,11 @@ func getConfigTestArchiveBlob(name string, tenantId string, clientId string,
 	clientSecret string, accountName string, containerName string) string {
 	return fmt.Sprintf(`resource "logzio_archive_logs" "%s" {
  storage_type = "BLOB"
- azure_blob_storage_settings {
-	tenant_id = "%s"
-	client_id = "%s"
-	client_secret = "%s"
-	account_name = "%s"
-	container_name = "%s" 
- }
+ tenant_id = "%s"
+ client_id = "%s"
+ client_secret = "%s"
+ account_name = "%s"
+ container_name = "%s" 
 }
 `, name, tenantId, clientId, clientSecret, accountName, containerName)
 }
@@ -280,14 +238,10 @@ func getConfigTestArchiveEmptyStorageType(name string, path string, accessKey st
 	return fmt.Sprintf(`resource "logzio_archive_logs" "%s" {
  storage_type = ""
  enabled = false
- amazon_s3_storage_settings {
-   credentials_type = "KEYS"
-   s3_path = "%s"
-   s3_secret_credentials {
-		access_key = "%s"
-		secret_key = "%s"
-	}
- }
+ credentials_type = "KEYS"
+ s3_path = "%s"
+ aws_access_key = "%s"
+ aws_secret_key = "%s"
 }
 `, name, path, accessKey, secretKey)
 }
@@ -296,14 +250,10 @@ func getConfigTestArchiveEmptyCredentialsType(name string, path string, accessKe
 	return fmt.Sprintf(`resource "logzio_archive_logs" "%s" {
  storage_type = "S3"
  enabled = false
- amazon_s3_storage_settings {
-   credentials_type = ""
-   s3_path = "%s"
-   s3_secret_credentials {
-		access_key = "%s"
-		secret_key = "%s"
-	}
- }
+ credentials_type = ""
+ s3_path = "%s"
+ aws_access_key = "%s"
+ aws_secret_key = "%s"
 }
 `, name, path, accessKey, secretKey)
 }

--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,9 @@ terraform import logzio_subaccount.my_subaccount <SUBACCOUNT-ID>
         - **Terraform 0.11** and lower will not be supported.
         - To read more about migrating to v2 of the `terraform-plugin-sdk` see [this article](https://www.terraform.io/plugin/sdkv2/guides/v2-upgrade-guide).
     - Removal of the `logzio_alert` resource. Use `logzio_alert_v2` instead.
+    - `logzio_archive_logs`:
+      - Removal of `s3_secret_credentials`. Use `aws_access_key` and `aws_secret_key` instead. See documentation for current configuration structure.
+      - Refactor code to match current API.
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>


### PR DESCRIPTION
- Removal of `s3_secret_credentials`. Use `aws_access_key` and `aws_secret_key` instead. See documentation for current configuration structure.
- Refactor code to match current API.
- Refactor resource + tests to match new sdk.